### PR TITLE
Allow a nil standard, and make that the default

### DIFF
--- a/phpcbf.el
+++ b/phpcbf.el
@@ -41,7 +41,7 @@
   "Format PHP code using PHP_CodeSniffer's phpcbf"
   :group 'tools)
 
-(defcustom phpcbf-executable (executable-find "phpcbf")
+(defcustom phpcbf-executable "phpcbf"
   "Location of the phpcbf executable."
   :group 'phpcbf
   :type 'string)
@@ -50,6 +50,11 @@
   "The name or path of the coding standard to use."
   :group 'phpcbf
   :type 'string)
+
+(defun phpcbf-executable ()
+  "Find the “phpcbf” executable or signal an error."
+  (or (executable-find phpcbf-executable)
+      (error "%s: executable not found" phpcbf-executable)))
 
 ;;;###autoload
 (defun phpcbf ()
@@ -68,7 +73,8 @@
 
           (setq status
                 (call-process-region
-                 (point-min) (point-max) phpcbf-executable
+                 (point-min) (point-max)
+                 (phpcbf-executable)
                  t keep-stderr t
                  "-d" "error_reporting=0"
                  standard


### PR DESCRIPTION
When no standard is given, phpcbf will look for a project-specific “phpcs.xml” file containing the rules. When no standard is given and no file is found it will use PEAR, making the behavior equivalent to the previous default.

I am not sure that the use of `buffer-file-coding-system` is correct - I think you need to use `find-operation-coding-system` - but I standardized my system on UTF-8 to the point I don't know how to test this stuff anymore, so I left it as it was.

This depends on #4; I can isolate it, but it would then conflict.