### PR TITLE
Improve handling of errors from call-process and phpcbf

### DIFF
--- a/phpcbf.el
+++ b/phpcbf.el
@@ -41,7 +41,7 @@
   "Format PHP code using PHP_CodeSniffer's phpcbf"
   :group 'tools)
 
-(defcustom phpcbf-executable (executable-find "phpcbf")
+(defcustom phpcbf-executable "phpcbf"
   "Location of the phpcbf executable."
   :group 'phpcbf
   :type 'string)
@@ -50,6 +50,11 @@
   "The name or path of the coding standard to use."
   :group 'phpcbf
   :type 'string)
+
+(defun phpcbf-executable ()
+  "Find the “phpcbf” executable or signal an error."
+  (or (executable-find phpcbf-executable)
+      (error "%s: executable not found" phpcbf-executable)))
 
 ;;;###autoload
 (defun phpcbf ()
@@ -68,7 +73,8 @@
 
           (setq status
                 (call-process-region
-                 (point-min) (point-max) phpcbf-executable
+                 (point-min) (point-max)
+                 (phpcbf-executable)
                  t keep-stderr t
                  "-d" "error_reporting=0"
                  standard


### PR DESCRIPTION
Do all formatting work in a temporary buffer. ‘call-process-region’ will delete text before trying to run the executable, and we could also fail later based on exit status. If either case we want to leave the original
buffer unchanged.

As signaling an error is no longer a threat to the main buffer, remove use of ‘unwind-protect’ (which wasn’t protecting the buffer anyway).

Do not split stdout/stderr. phpcbf returns some error messages (e.g. an invalid “--standard=…” option) on stdout, and that message should be captured and provided back to the user (e.g. the confusion in issue #2). 

As failures now leave the source buffer unchanged, allow saving to continue even when phpcbf fails. Present a warning with the failure message.

Fix quotes within error messages.

Once again this contains my previous PRs; since it ends up reindenting the whole function it necessarily conflicts with them. If you want any of the three changes individually I can rebase the PRs.