### PR TITLE
add exclude rule option

### DIFF
--- a/phpcbf.el
+++ b/phpcbf.el
@@ -54,6 +54,11 @@ falling back to PEAR if none is found."
   :group 'phpcbf
   :type '(choice string (const nil)))
 
+(defcustom phpcbf-exclude nil
+  "Exclude rule(s). Comma separate if multiple."
+  :group 'phpcbf
+  :type '(choice string (const nil)))
+
 (defun phpcbf-executable ()
   "Find the “phpcbf” executable or signal an error."
   (or (executable-find phpcbf-executable)
@@ -63,6 +68,8 @@ falling back to PEAR if none is found."
   "Generate the options list for running “phpcbf”."
   (append (when phpcbf-standard
             (list (format "--standard=%s" phpcbf-standard)))
+          (if phpcbf-exclude
+            (list (format "--exclude=%s" phpcbf-exclude)))
           (list (s-chop-suffixes
                  '("-unix" "-dos" "-mac")
                  (format "--encoding=%s" buffer-file-coding-system))


### PR DESCRIPTION
Please note I am not a lisp programmer, so this may not be the right way to do this.

This can be used like so:

```elisp
(use-package phpcbf
  :init
  (setq phpcbf-executable "/usr/bin/phpcbf"
        phpcbf-standard "PSR2"
        phpcbf-exclude "PSR2.ControlStructures.ElseIfDeclaration,PSR2.Classes.ClassDeclaration")))))
```